### PR TITLE
update patient

### DIFF
--- a/app/src/main/java/GaitVision/com/ui/PatientCreateActivity.kt
+++ b/app/src/main/java/GaitVision/com/ui/PatientCreateActivity.kt
@@ -267,6 +267,4 @@ class PatientCreateActivity : BaseActivity() {
             }
         }
     }
-    }
 }
-


### PR DESCRIPTION
#33 

Modified `savePatient` to distinguish between creating a new patient and updating an existing one.

Before: Always used `patientDao.insertPatient`, which used `OnConflictStrategy.REPLACE`. This caused the old patient record to be deleted (triggering `CASCADE` delete on analysis results) and a new one inserted.
After: Uses `patientDao.updatePatient` for existing records, which updates without deleting the row.