### PR TITLE
add batch analysis feature + pipeline cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,6 +191,10 @@ refactor2.py
 build_error.txt
 build_error_utf8.txt
 
+# Research/reference PDFs dropped in the working tree
+batch/
+*.pdf
+
 # Local Android Studio metadata (machine-specific)
 .idea/workspace.xml
 .idea/caches/

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -117,6 +117,14 @@
             android:parentActivityName="GaitVision.com.ui.PatientProfileActivity"
             tools:ignore="DiscouragedApi,LockedOrientationActivity" />
 
+        <activity
+            android:name="GaitVision.com.ui.BatchAnalysisActivity"
+            android:exported="false"
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.GaitVision"
+            android:parentActivityName="GaitVision.com.ui.PatientProfileActivity"
+            tools:ignore="DiscouragedApi,LockedOrientationActivity" />
+
         <!-- Utility Activities -->
         <activity
             android:name="GaitVision.com.ui.HelpActivity"

--- a/app/src/main/java/GaitVision/com/SessionPersistence.kt
+++ b/app/src/main/java/GaitVision/com/SessionPersistence.kt
@@ -1,0 +1,139 @@
+package GaitVision.com
+
+import android.content.Context
+import android.util.Log
+import GaitVision.com.data.AnalysisResult
+import GaitVision.com.data.AppDatabase
+import GaitVision.com.data.SignalData
+import GaitVision.com.data.repository.AnalysisResultRepository
+import GaitVision.com.data.repository.SignalDataRepository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONArray
+import org.json.JSONObject
+
+// Saves the current AnalysisSession to DB: one AnalysisResult + N SignalData rows.
+// Used by both the single-video flow and batch.
+// Throws on DB error so the caller can decide what to do (toast vs mark row failed).
+// Returns the new result id.
+suspend fun persistCurrentSession(
+    context: Context,
+    db: AppDatabase,
+    patientId: Int,
+    videoFileName: String? = null,
+): Long? = withContext(Dispatchers.IO) {
+    val resolvedName = videoFileName ?: lookupDisplayName(context)
+    val features = AnalysisSession.extractedFeatures
+    val score = AnalysisSession.scoringResult
+    val diagnostics = AnalysisSession.extractionDiagnostics
+
+    val result = AnalysisResult(
+        patientId = patientId,
+        videoFileName = resolvedName,
+        videoLengthMicroseconds = AnalysisSession.videoLength,
+        recordedAt = AnalysisSession.recordingDate,
+
+        // scores
+        overallScore = score?.getScoreForDatabase(),
+        aeScore = score?.aeScore,
+        ridgeScore = score?.ridgeScore,
+        pcaScore = score?.pcaScore,
+
+        // pipeline metadata
+        stepSignalMode = AnalysisSession.stepSignalMode,
+        validStrideCount = features?.valid_stride_count ?: 0,
+        qualityFlag = diagnostics?.qualityFlag?.name,
+
+        // diagnostics
+        fpsDetected = diagnostics?.fpsDetected,
+        numFramesTotal = diagnostics?.numFramesTotal ?: 0,
+        numFramesValid = diagnostics?.numFramesValid ?: 0,
+        validFrameRate = diagnostics?.validFrameRate,
+        numStepsDetected = diagnostics?.numStepsDetected ?: 0,
+        walkingDirection = diagnostics?.walkingDirection,
+        wasFlipped = diagnostics?.wasFlipped ?: false,
+
+        // 16 features
+        cadenceSpm = features?.cadence_spm,
+        strideTimeS = features?.stride_time_s,
+        strideTimeCv = features?.stride_time_cv,
+        stepTimeAsymmetry = features?.step_time_asymmetry,
+        strideLengthNorm = features?.stride_length_norm,
+        strideAmpNorm = features?.stride_amp_norm,
+        stepLengthAsymmetry = features?.step_length_asymmetry,
+        kneeLeftRom = features?.knee_left_rom,
+        kneeRightRom = features?.knee_right_rom,
+        kneeLeftMax = features?.knee_left_max,
+        kneeRightMax = features?.knee_right_max,
+        ldjKneeLeft = features?.ldj_knee_left,
+        ldjKneeRight = features?.ldj_knee_right,
+        ldjHip = features?.ldj_hip,
+        trunkLeanStdDeg = features?.trunk_lean_std_deg,
+        interAnkleCv = features?.inter_ankle_cv,
+
+        stridesJson = AnalysisSession.extractedStrides?.let { strides ->
+            JSONArray().apply {
+                strides.forEach { s ->
+                    put(JSONObject().apply {
+                        put("sf", s.startFrame)
+                        put("ef", s.endFrame)
+                        put("st", s.startTimeS)
+                        put("et", s.endTimeS)
+                        put("s1f", s.step1Frame)
+                        put("s2f", s.step2Frame)
+                        put("s1t", s.step1TimeS)
+                        put("s2t", s.step2TimeS)
+                        put("v", s.isValid)
+                        put("r", s.invalidReason ?: JSONObject.NULL)
+                    })
+                }
+            }.toString()
+        },
+        selectedStrideIndicesJson = AnalysisSession.selectedStrideIndices?.let {
+            JSONArray(it).toString()
+        }
+    )
+
+    val resultRepo = AnalysisResultRepository(db.analysisResultDao())
+    val signalRepo = SignalDataRepository(db.signalDataDao())
+
+    val resultId = resultRepo.insertResult(result)
+    AnalysisSession.currentResultId = resultId
+
+    // signals are optional; not every quality flag produces them
+    val signals = AnalysisSession.extractedSignals
+    if (signals != null) {
+        val maxFrames = signals.kneeAngleLeft.size
+        val rows = ArrayList<SignalData>(maxFrames)
+        for (frame in 0 until maxFrames) {
+            rows.add(SignalData(
+                resultId = resultId,
+                frameNumber = frame,
+                interAnkleDist = signals.interAnkleDist.getOrNull(frame)?.takeIf { !it.isNaN() },
+                kneeAngleLeft = signals.kneeAngleLeft.getOrNull(frame)?.takeIf { !it.isNaN() },
+                kneeAngleRight = signals.kneeAngleRight.getOrNull(frame)?.takeIf { !it.isNaN() },
+                trunkAngle = signals.trunkAngle.getOrNull(frame)?.takeIf { !it.isNaN() },
+                ankleLeftY = signals.ankleLeftY.getOrNull(frame)?.takeIf { !it.isNaN() },
+                ankleRightY = signals.ankleRightY.getOrNull(frame)?.takeIf { !it.isNaN() },
+                hipLeftY = signals.hipLeftY.getOrNull(frame)?.takeIf { !it.isNaN() },
+                hipRightY = signals.hipRightY.getOrNull(frame)?.takeIf { !it.isNaN() },
+                ankleLeftVy = signals.ankleLeftVy.getOrNull(frame)?.takeIf { !it.isNaN() },
+                ankleRightVy = signals.ankleRightVy.getOrNull(frame)?.takeIf { !it.isNaN() },
+                isValid = signals.isValid.getOrNull(frame) ?: true,
+                timestamp = signals.timestamps.getOrNull(frame)?.takeIf { !it.isNaN() }
+            ))
+        }
+        if (rows.isNotEmpty()) signalRepo.insertSignalDataList(rows)
+        Log.d("SessionPersistence", "saved result $resultId with ${rows.size} signal rows")
+    } else {
+        Log.d("SessionPersistence", "saved result $resultId (no signals)")
+    }
+
+    resultId
+}
+
+// Thin wrapper so we can call the shared util with the session's URI.
+private fun lookupDisplayName(context: Context): String {
+    val uri = AnalysisSession.galleryUri ?: return ""
+    return lookupDisplayName(context, uri)
+}

--- a/app/src/main/java/GaitVision/com/VideoMetadataUtils.kt
+++ b/app/src/main/java/GaitVision/com/VideoMetadataUtils.kt
@@ -1,0 +1,90 @@
+package GaitVision.com
+
+import android.content.Context
+import android.media.MediaMetadataRetriever
+import android.net.Uri
+import android.provider.MediaStore
+import java.text.SimpleDateFormat
+import java.util.Locale
+import java.util.TimeZone
+
+// Tries to find the actual capture date for a video URI.
+// Fallback order:
+//   1. MediaStore DATE_TAKEN (most reliable for gallery clips)
+//   2. METADATA_KEY_DATE embedded in the container (good for imported files)
+//   3. MediaStore DATE_MODIFIED * 1000 (file-system timestamp, last resort)
+// Returns null if nothing usable is found; callers decide what to do (today, show "unknown", etc.)
+fun extractRecordingDate(context: Context, uri: Uri): Long? {
+    // 1. MediaStore - DATE_TAKEN and DATE_MODIFIED in one query
+    try {
+        context.contentResolver.query(
+            uri,
+            arrayOf(MediaStore.Video.Media.DATE_TAKEN, MediaStore.MediaColumns.DATE_MODIFIED),
+            null, null, null
+        )?.use { cursor ->
+            if (cursor.moveToFirst()) {
+                val takenIdx = cursor.getColumnIndex(MediaStore.Video.Media.DATE_TAKEN)
+                val modIdx = cursor.getColumnIndex(MediaStore.MediaColumns.DATE_MODIFIED)
+                if (takenIdx >= 0) {
+                    val taken = cursor.getLong(takenIdx)
+                    if (taken > 0) return taken
+                }
+                // DATE_MODIFIED is seconds since epoch, not millis
+                if (modIdx >= 0) {
+                    val modified = cursor.getLong(modIdx)
+                    if (modified > 0) return modified * 1000L
+                }
+            }
+        }
+    } catch (_: Exception) {}
+
+    // 2. Embedded container metadata (works for files not indexed by MediaStore)
+    try {
+        val retriever = MediaMetadataRetriever()
+        retriever.setDataSource(context, uri)
+        val raw = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DATE)
+        retriever.release()
+        if (!raw.isNullOrBlank()) {
+            val parsed = parseMetadataDate(raw)
+            if (parsed != null) return parsed
+        }
+    } catch (_: Exception) {}
+
+    return null
+}
+
+// METADATA_KEY_DATE is technically ISO8601 but encoders disagree on the exact format.
+// Cover the common variants in order of likelihood.
+private val DATE_FORMATS = listOf(
+    "yyyyMMdd'T'HHmmss.SSS'Z'",
+    "yyyyMMdd'T'HHmmss'Z'",
+    "yyyy-MM-dd'T'HH:mm:ss'Z'",
+    "yyyy-MM-dd HH:mm:ss",
+)
+
+private fun parseMetadataDate(raw: String): Long? {
+    for (fmt in DATE_FORMATS) {
+        try {
+            val sdf = SimpleDateFormat(fmt, Locale.US).apply {
+                timeZone = TimeZone.getTimeZone("UTC")
+            }
+            val date = sdf.parse(raw)
+            if (date != null) return date.time
+        } catch (_: Exception) {}
+    }
+    return null
+}
+
+// Shared display-name lookup used by both BatchAnalysisActivity and SessionPersistence.
+// Returns empty string on failure; callers fall back however they like.
+fun lookupDisplayName(context: Context, uri: Uri): String {
+    return try {
+        context.contentResolver
+            .query(uri, arrayOf(android.provider.OpenableColumns.DISPLAY_NAME), null, null, null)
+            ?.use { c -> if (c.moveToFirst()) c.getString(0) else null }
+            ?: uri.lastPathSegment
+            ?: ""
+    } catch (_: Exception) {
+        uri.lastPathSegment ?: ""
+    }
+}

--- a/app/src/main/java/GaitVision/com/imageProcessing.kt
+++ b/app/src/main/java/GaitVision/com/imageProcessing.kt
@@ -17,12 +17,6 @@ import android.os.Build
 import android.net.Uri
 import android.util.Log
 import android.view.Surface
-import android.view.View
-import android.view.View.GONE
-import android.view.View.VISIBLE
-import android.widget.ProgressBar
-import android.widget.TextView
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.FileProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -45,6 +39,11 @@ import GaitVision.com.gait.GaitDiagnostics
 import GaitVision.com.gait.GaitScorer
 import GaitVision.com.gait.ScoringResult
 import GaitVision.com.gait.QualityFlag
+
+// stage is "processing", "retry", or "done". percent is 0..100 within that stage.
+// Lets the caller render progress however it wants (single-video bar, per-row
+// status in batch) without dragging view IDs into the pipeline.
+typealias ProgressReporter = (stage: String, percent: Int) -> Unit
 
 /**
  * Convert YUV_420_888 Image (from MediaCodec) to ARGB Bitmap.
@@ -281,17 +280,6 @@ fun releaseMediaPipeBackend() {
 
 
 /**
- * Hide progress UI elements after processing.
- */
-private suspend fun hideProgressUI(activity: AppCompatActivity) {
-    withContext(Dispatchers.Main) {
-        activity.findViewById<TextView>(R.id.SplittingText).visibility = GONE
-        activity.findViewById<ProgressBar>(R.id.splittingBar).visibility = GONE
-        activity.findViewById<TextView>(R.id.splittingProgressValue).visibility = GONE
-    }
-}
-
-/**
  * Holds mutable state for video encoding across frames.
  */
 private class EncoderState(
@@ -480,7 +468,11 @@ fun processFrameWithMediaPipe(
  * 8. If extraction fails (quality != OK), could retry with ROI
  * 9. Compute gait scores
  */
-suspend fun ProcVidEmpty(context: Context, outputPath: String, activity: AppCompatActivity): Uri? {
+suspend fun ProcVidEmpty(
+    context: Context,
+    outputPath: String,
+    onProgress: ProgressReporter? = null
+): Uri? {
     val TAG = "ImageProcessing"
     
     // Clear all data
@@ -496,19 +488,7 @@ suspend fun ProcVidEmpty(context: Context, outputPath: String, activity: AppComp
         return null
     }
 
-    // Setup UI - single progress bar for streaming
-    withContext(Dispatchers.Main) {
-        activity.findViewById<TextView>(R.id.SplittingText).text = "Processing..."
-        activity.findViewById<TextView>(R.id.SplittingText).visibility = VISIBLE
-        activity.findViewById<ProgressBar>(R.id.splittingBar).visibility = VISIBLE
-        activity.findViewById<ProgressBar>(R.id.splittingBar).progress = 0
-        activity.findViewById<TextView>(R.id.splittingProgressValue).visibility = VISIBLE
-        activity.findViewById<TextView>(R.id.splittingProgressValue).text = " 0%"
-        // Hide the second progress bar - we use only one now
-        activity.findViewById<TextView>(R.id.CreationText).visibility = GONE
-        activity.findViewById<ProgressBar>(R.id.VideoCreation).visibility = GONE
-        activity.findViewById<TextView>(R.id.CreatingProgressValue).visibility = GONE
-    }
+    onProgress?.invoke("processing", 0)
 
     // === Set up MediaExtractor for FAST video reading ===
     val extractor = MediaExtractor()
@@ -601,7 +581,7 @@ suspend fun ProcVidEmpty(context: Context, outputPath: String, activity: AppComp
         Log.e(TAG, "Falling back to slow getFrameAtTime method")
         extractor.release()
         // Fallback to slow method
-        return procVidEmptyFallback(context, outputPath, activity)
+        return procVidEmptyFallback(context, outputPath, onProgress)
     }
     
     // Initialize MediaPipe
@@ -646,9 +626,7 @@ suspend fun ProcVidEmpty(context: Context, outputPath: String, activity: AppComp
     Log.d(TAG, "FAST STREAMING: Processing ~$totalFrames frames with MediaCodec")
     Log.d(TAG, "GPU delegate: ${mediaPipeBackend?.isUsingGpu() ?: false}, CLAHE: $enableCLAHE")
 
-    // Cache view references and progress state to avoid repeated findViewById + unnecessary context switches
-    val progressBar = activity.findViewById<ProgressBar>(R.id.splittingBar)
-    val progressText = activity.findViewById<TextView>(R.id.splittingProgressValue)
+    // only fire the callback when the integer percent actually changes
     var lastProgress = -1
 
     // === FAST MediaCodec STREAMING LOOP ===
@@ -712,10 +690,7 @@ suspend fun ProcVidEmpty(context: Context, outputPath: String, activity: AppComp
                             val progress = ((frameIndex.toFloat() / totalFrames) * 100).toInt().coerceIn(0, 100)
                             if (progress != lastProgress) {
                                 lastProgress = progress
-                                withContext(Dispatchers.Main) {
-                                    progressBar.progress = progress
-                                    progressText.text = " $progress%"
-                                }
+                                onProgress?.invoke("processing", progress)
                             }
                         } else {
                             decoder.releaseOutputBuffer(outputBufferId, false)
@@ -739,13 +714,12 @@ suspend fun ProcVidEmpty(context: Context, outputPath: String, activity: AppComp
     extractor.release()
     releaseMediaPipeBackend()
 
-    // Hide progress UI
-    hideProgressUI(activity)
+    onProgress?.invoke("processing", 100)
 
     Log.d(TAG, "FAST STREAMING complete. Processed $frameIndex frames, ${AnalysisSession.poseFrames.size} poses detected")
     
     // Feature extraction (uses poseFrames which is small)
-    extractGaitFeatures(context, width, height, frameIndex, activity)
+    extractGaitFeatures(context, width, height, frameIndex, onProgress)
     
     // Free heavy memory now that processing is done
     val frameCount = AnalysisSession.poseFrames.size
@@ -762,6 +736,7 @@ suspend fun ProcVidEmpty(context: Context, outputPath: String, activity: AppComp
     Log.d(TAG, "Cleared frameList and poseFrames ($frameCount poses freed)")
     
     Log.d(TAG, "Pipeline complete")
+    onProgress?.invoke("done", 100)
 
     val outputFile = File(outputPath)
     val uri = FileProvider.getUriForFile(context, "${context.packageName}.provider", outputFile)
@@ -773,7 +748,11 @@ suspend fun ProcVidEmpty(context: Context, outputPath: String, activity: AppComp
  * Fallback video processing using slow getFrameAtTime() method.
  * Used if MediaCodec initialization fails.
  */
-private suspend fun procVidEmptyFallback(context: Context, outputPath: String, activity: AppCompatActivity): Uri? {
+private suspend fun procVidEmptyFallback(
+    context: Context,
+    outputPath: String,
+    onProgress: ProgressReporter? = null
+): Uri? {
     val TAG = "ImageProcessing"
     Log.w(TAG, "Using SLOW fallback method (getFrameAtTime)")
     
@@ -839,10 +818,7 @@ private suspend fun procVidEmptyFallback(context: Context, outputPath: String, a
         }
         
         val progress = ((currTimeUs.toDouble() / videoLengthUs) * 100).toInt().coerceIn(0, 100)
-        withContext(Dispatchers.Main) {
-            activity.findViewById<ProgressBar>(R.id.splittingBar).progress = progress
-            activity.findViewById<TextView>(R.id.splittingProgressValue).text = " $progress%"
-        }
+        onProgress?.invoke("processing", progress)
         
         currTimeUs += frameIntervalUs
     }
@@ -852,11 +828,12 @@ private suspend fun procVidEmptyFallback(context: Context, outputPath: String, a
     retriever.release()
     releaseMediaPipeBackend()
 
-    hideProgressUI(activity)
+    onProgress?.invoke("processing", 100)
 
-    extractGaitFeatures(context, width, height, frameIndex, activity)
+    extractGaitFeatures(context, width, height, frameIndex, onProgress)
 
     val outputFile = File(outputPath)
+    onProgress?.invoke("done", 100)
     return FileProvider.getUriForFile(context, "${context.packageName}.provider", outputFile)
 }
 
@@ -874,7 +851,7 @@ private suspend fun extractGaitFeatures(
     frameWidth: Int, 
     frameHeight: Int, 
     totalFrames: Int,
-    activity: AppCompatActivity
+    onProgress: ProgressReporter? = null
 ) {
     Log.d("ImageProcessing", "Starting feature extraction with ${AnalysisSession.poseFrames.size} pose frames")
 
@@ -912,15 +889,9 @@ private suspend fun extractGaitFeatures(
         // If first pass failed and ROI retry is enabled, reprocess with ROI tracking
         if (features == null && enableROIRetry && diagnostics.qualityFlag != QualityFlag.OK) {
             Log.d("ImageProcessing", "First pass: ${diagnostics.qualityFlag} - retrying with ROI tracking...")
+            onProgress?.invoke("retry", 0)
             
-            // Update UI to show ROI retry in progress
-            withContext(Dispatchers.Main) {
-                activity.findViewById<TextView>(R.id.CreationText).text = "Retrying with ROI tracking..."
-                activity.findViewById<ProgressBar>(R.id.VideoCreation).progress = 0
-                activity.findViewById<TextView>(R.id.CreatingProgressValue).text = " 0%"
-            }
-            
-            val roiResult = reprocessWithRoiTracking(context, frameWidth, frameHeight, totalFrames, fps, activity)
+            val roiResult = reprocessWithRoiTracking(context, frameWidth, frameHeight, totalFrames, fps, onProgress)
             if (roiResult != null) {
                 val (roiPoseSequence, roiFrames) = roiResult
                 val normalizedRoiSeq = featureExtractor.normalizeDirection(roiPoseSequence)
@@ -938,12 +909,7 @@ private suspend fun extractGaitFeatures(
                 }
             }
             
-            // Update UI to show completion
-            withContext(Dispatchers.Main) {
-                activity.findViewById<TextView>(R.id.CreationText).text = "Processing Complete"
-                activity.findViewById<ProgressBar>(R.id.VideoCreation).progress = 100
-                activity.findViewById<TextView>(R.id.CreatingProgressValue).text = " 100%"
-            }
+            onProgress?.invoke("retry", 100)
         }
         
         AnalysisSession.extractedFeatures = features
@@ -1000,7 +966,7 @@ private suspend fun reprocessWithRoiTracking(
     frameHeight: Int,
     totalFrames: Int,
     fps: Float,
-    activity: AppCompatActivity
+    onProgress: ProgressReporter? = null
 ): Pair<PoseSequence, List<PoseFrame>>? {
     // BUG: frameList is always empty in fast path - see docstring above
     if (AnalysisSession.frameList.isEmpty()) return null
@@ -1016,12 +982,8 @@ private suspend fun reprocessWithRoiTracking(
     Log.d("ImageProcessing", "Reprocessing ${AnalysisSession.frameList.size} frames with ROI tracking...")
     
     for ((frameIndex, frame) in AnalysisSession.frameList.withIndex()) {
-        // Update progress UI
         val progress = ((frameIndex + 1) * 100 / listSize)
-        withContext(Dispatchers.Main) {
-            activity.findViewById<ProgressBar>(R.id.VideoCreation).progress = progress
-            activity.findViewById<TextView>(R.id.CreatingProgressValue).text = " $progress%"
-        }
+        onProgress?.invoke("retry", progress)
         val timestampMs = (frameIndex * 1000L / fps).toLong()
         
         // Determine processing region based on ROI state machine

--- a/app/src/main/java/GaitVision/com/ui/AnalysisActivity.kt
+++ b/app/src/main/java/GaitVision/com/ui/AnalysisActivity.kt
@@ -9,6 +9,7 @@ import android.util.Log
 import android.view.View
 import android.widget.LinearLayout
 import android.widget.MediaController
+import android.widget.ProgressBar
 import android.widget.TextView
 import android.widget.Toast
 import android.widget.VideoView
@@ -22,17 +23,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import GaitVision.com.R
-import GaitVision.com.data.AnalysisResult
-import GaitVision.com.data.SignalData
 import GaitVision.com.data.AppDatabase
-import GaitVision.com.data.repository.AnalysisResultRepository
-import GaitVision.com.data.repository.SignalDataRepository
 import GaitVision.com.data.repository.PatientRepository
 import GaitVision.com.ProcVidEmpty
 import GaitVision.com.AnalysisSession
-import android.provider.OpenableColumns
-import org.json.JSONArray
-import org.json.JSONObject
+import GaitVision.com.persistCurrentSession
 import java.io.File
 
 class AnalysisActivity : BaseActivity() {
@@ -171,7 +166,10 @@ class AnalysisActivity : BaseActivity() {
                 }
 
                 AnalysisSession.editedUri = withContext(Dispatchers.IO) {
-                    ProcVidEmpty(this@AnalysisActivity, outputFilePath, this@AnalysisActivity)
+                    ProcVidEmpty(this@AnalysisActivity, outputFilePath) { stage, percent ->
+                        // pipeline runs on IO, view writes need Main
+                        runOnUiThread { updateProcessingProgress(stage, percent) }
+                    }
                 }
 
                 // Save video and angle data to database
@@ -200,129 +198,50 @@ class AnalysisActivity : BaseActivity() {
         }
     }
 
+    private var processingUiInitialized = false
+
+    // Drives the splitting progress bar from pipeline callbacks. The second
+    // bar (CreationText/VideoCreation) stayed hidden in the old flow too; it
+    // was only ever shown during the disabled ROI retry path.
+    private fun updateProcessingProgress(stage: String, percent: Int) {
+        val splittingText = findViewById<TextView>(R.id.SplittingText)
+        val splittingBar = findViewById<ProgressBar>(R.id.splittingBar)
+        val splittingValue = findViewById<TextView>(R.id.splittingProgressValue)
+
+        when (stage) {
+            "processing" -> {
+                if (!processingUiInitialized) {
+                    splittingText.text = "Processing..."
+                    splittingText.visibility = View.VISIBLE
+                    splittingBar.visibility = View.VISIBLE
+                    splittingValue.visibility = View.VISIBLE
+                    findViewById<TextView>(R.id.CreationText).visibility = View.GONE
+                    findViewById<ProgressBar>(R.id.VideoCreation).visibility = View.GONE
+                    findViewById<TextView>(R.id.CreatingProgressValue).visibility = View.GONE
+                    processingUiInitialized = true
+                }
+                splittingBar.progress = percent
+                splittingValue.text = " $percent%"
+            }
+            "done" -> {
+                splittingText.visibility = View.GONE
+                splittingBar.visibility = View.GONE
+                splittingValue.visibility = View.GONE
+                processingUiInitialized = false
+            }
+        }
+    }
+
     private suspend fun saveToDatabase(database: AppDatabase, outputPath: String) {
         if (!shouldSave || AnalysisSession.currentPatientId == null || AnalysisSession.editedUri == null) return
-
         try {
-            val resultRepo = AnalysisResultRepository(database.analysisResultDao())
-            val signalRepo = SignalDataRepository(database.signalDataDao())
-
-            withContext(Dispatchers.IO) {
-                val videoName = AnalysisSession.galleryUri?.let { uri ->
-                    contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)?.use { cursor ->
-                        if (cursor.moveToFirst()) cursor.getString(0) else null
-                    }
-                } ?: ""
-                val features = AnalysisSession.extractedFeatures
-                val score = AnalysisSession.scoringResult
-                val diagnostics = AnalysisSession.extractionDiagnostics
-
-                // Save analysis result (replaces old Video + GaitScore saves)
-                val result = AnalysisResult(
-                    patientId = AnalysisSession.currentPatientId!!,
-                    videoFileName = videoName,
-                    videoLengthMicroseconds = AnalysisSession.videoLength,
-                    recordedAt = AnalysisSession.recordingDate,
-
-                    // Scores
-                    overallScore = score?.getScoreForDatabase(),
-                    aeScore = score?.aeScore,
-                    ridgeScore = score?.ridgeScore,
-                    pcaScore = score?.pcaScore,
-
-                    // Pipeline metadata
-                    stepSignalMode = AnalysisSession.stepSignalMode,
-                    validStrideCount = features?.valid_stride_count ?: 0,
-                    qualityFlag = diagnostics?.qualityFlag?.name,
-
-                    // Diagnostics
-                    fpsDetected = diagnostics?.fpsDetected,
-                    numFramesTotal = diagnostics?.numFramesTotal ?: 0,
-                    numFramesValid = diagnostics?.numFramesValid ?: 0,
-                    validFrameRate = diagnostics?.validFrameRate,
-                    numStepsDetected = diagnostics?.numStepsDetected ?: 0,
-                    walkingDirection = diagnostics?.walkingDirection,
-                    wasFlipped = diagnostics?.wasFlipped ?: false,
-
-                    // 16 features
-                    cadenceSpm = features?.cadence_spm,
-                    strideTimeS = features?.stride_time_s,
-                    strideTimeCv = features?.stride_time_cv,
-                    stepTimeAsymmetry = features?.step_time_asymmetry,
-                    strideLengthNorm = features?.stride_length_norm,
-                    strideAmpNorm = features?.stride_amp_norm,
-                    stepLengthAsymmetry = features?.step_length_asymmetry,
-                    kneeLeftRom = features?.knee_left_rom,
-                    kneeRightRom = features?.knee_right_rom,
-                    kneeLeftMax = features?.knee_left_max,
-                    kneeRightMax = features?.knee_right_max,
-                    ldjKneeLeft = features?.ldj_knee_left,
-                    ldjKneeRight = features?.ldj_knee_right,
-                    ldjHip = features?.ldj_hip,
-                    trunkLeanStdDeg = features?.trunk_lean_std_deg,
-                    interAnkleCv = features?.inter_ankle_cv,
-
-                    stridesJson = AnalysisSession.extractedStrides?.let { strides ->
-                        JSONArray().apply {
-                            strides.forEach { s ->
-                                put(JSONObject().apply {
-                                    put("sf", s.startFrame)
-                                    put("ef", s.endFrame)
-                                    put("st", s.startTimeS)
-                                    put("et", s.endTimeS)
-                                    put("s1f", s.step1Frame)
-                                    put("s2f", s.step2Frame)
-                                    put("s1t", s.step1TimeS)
-                                    put("s2t", s.step2TimeS)
-                                    put("v", s.isValid)
-                                    put("r", s.invalidReason ?: JSONObject.NULL)
-                                })
-                            }
-                        }.toString()
-                    },
-                    selectedStrideIndicesJson = AnalysisSession.selectedStrideIndices?.let {
-                        JSONArray(it).toString()
-                    }
-                )
-                val resultId = resultRepo.insertResult(result)
-                AnalysisSession.currentResultId = resultId
-
-                // Save per-frame signal data for graph reload
-                val signals = AnalysisSession.extractedSignals
-                if (signals != null) {
-                    val signalDataList = mutableListOf<SignalData>()
-                    val maxFrames = signals.kneeAngleLeft.size
-
-                    for (frame in 0 until maxFrames) {
-                        signalDataList.add(SignalData(
-                            resultId = resultId,
-                            frameNumber = frame,
-                            interAnkleDist = signals.interAnkleDist.getOrNull(frame)?.takeIf { !it.isNaN() },
-                            kneeAngleLeft = signals.kneeAngleLeft.getOrNull(frame)?.takeIf { !it.isNaN() },
-                            kneeAngleRight = signals.kneeAngleRight.getOrNull(frame)?.takeIf { !it.isNaN() },
-                            trunkAngle = signals.trunkAngle.getOrNull(frame)?.takeIf { !it.isNaN() },
-                            ankleLeftY = signals.ankleLeftY.getOrNull(frame)?.takeIf { !it.isNaN() },
-                            ankleRightY = signals.ankleRightY.getOrNull(frame)?.takeIf { !it.isNaN() },
-                            hipLeftY = signals.hipLeftY.getOrNull(frame)?.takeIf { !it.isNaN() },
-                            hipRightY = signals.hipRightY.getOrNull(frame)?.takeIf { !it.isNaN() },
-                            ankleLeftVy = signals.ankleLeftVy.getOrNull(frame)?.takeIf { !it.isNaN() },
-                            ankleRightVy = signals.ankleRightVy.getOrNull(frame)?.takeIf { !it.isNaN() },
-                            isValid = signals.isValid.getOrNull(frame) ?: true,
-                            timestamp = signals.timestamps.getOrNull(frame)?.takeIf { !it.isNaN() }
-                        ))
-                    }
-
-                    if (signalDataList.isNotEmpty()) {
-                        signalRepo.insertSignalDataList(signalDataList)
-                    }
-
-                    Log.d("AnalysisActivity", "Saved result ID: $resultId with ${signalDataList.size} signal records")
-                } else {
-                    Log.d("AnalysisActivity", "Saved result ID: $resultId (no signals)")
-                }
-            }
+            persistCurrentSession(
+                context = this@AnalysisActivity,
+                db = database,
+                patientId = AnalysisSession.currentPatientId!!
+            )
         } catch (e: Exception) {
-            Log.e("AnalysisActivity", "Error saving to database: ${e.message}", e)
+            Log.e("AnalysisActivity", "DB save failed: ${e.message}", e)
             withContext(Dispatchers.Main) {
                 Toast.makeText(this@AnalysisActivity, "Warning: failed to save to database", Toast.LENGTH_LONG).show()
             }

--- a/app/src/main/java/GaitVision/com/ui/AnalysisHistoryActivity.kt
+++ b/app/src/main/java/GaitVision/com/ui/AnalysisHistoryActivity.kt
@@ -88,7 +88,8 @@ class AnalysisHistoryActivity : BaseActivity() {
 
         if (patientIdArg <= 0) { finish(); return }
 
-        setupCommonHeader("Analysis History — $patientName")
+        setupCommonHeader("Analysis History")
+        setHeaderSubtitle(patientName)
 
         analysisResultDao = AppDatabase.getDatabase(this).analysisResultDao()
 

--- a/app/src/main/java/GaitVision/com/ui/BaseActivity.kt
+++ b/app/src/main/java/GaitVision/com/ui/BaseActivity.kt
@@ -43,9 +43,12 @@ abstract class BaseActivity : AppCompatActivity() {
         }
     }
 
-    /**
-     * custom back button action
-     */
+    protected fun setHeaderSubtitle(subtitle: String) {
+        val tv = findViewById<TextView>(R.id.tvSubtitle) ?: return
+        tv.text = subtitle
+        tv.visibility = if (subtitle.isNotEmpty()) View.VISIBLE else View.GONE
+    }
+
     protected fun setCustomBackAction(action: () -> Unit) {
         btnBack?.apply {
             visibility = View.VISIBLE

--- a/app/src/main/java/GaitVision/com/ui/BatchAnalysisActivity.kt
+++ b/app/src/main/java/GaitVision/com/ui/BatchAnalysisActivity.kt
@@ -1,0 +1,419 @@
+package GaitVision.com.ui
+
+import android.app.AlertDialog
+import android.app.DatePickerDialog
+import android.net.Uri
+import android.os.Bundle
+import android.util.Log
+import android.view.View
+import android.widget.LinearLayout
+import android.widget.ProgressBar
+import android.widget.TextView
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import GaitVision.com.AnalysisSession
+import GaitVision.com.ProcVidEmpty
+import GaitVision.com.R
+import GaitVision.com.data.AppDatabase
+import GaitVision.com.data.repository.PatientRepository
+import GaitVision.com.extractRecordingDate
+import GaitVision.com.lookupDisplayName
+import GaitVision.com.persistCurrentSession
+import GaitVision.com.ui.adapter.BatchVideoAdapter
+import GaitVision.com.ui.adapter.BatchVideoRow
+import GaitVision.com.ui.adapter.BatchVideoStatus
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+
+class BatchAnalysisActivity : BaseActivity() {
+
+    companion object {
+        const val EXTRA_PATIENT_ID = "patientId"
+    }
+
+    // hero card
+    private lateinit var tvPatientName: TextView
+    private lateinit var tvPatientId: TextView
+    private lateinit var tvSelectedCount: TextView
+    private lateinit var tvDoneCount: TextView
+    private lateinit var tvFailedCount: TextView
+    private lateinit var tvLastScore: TextView
+
+    // action card
+    private lateinit var btnPick: LinearLayout
+    private lateinit var btnStart: LinearLayout
+    private lateinit var btnOverrideDate: LinearLayout
+    private lateinit var tvOverrideDateValue: TextView
+
+    // progress card
+    private lateinit var cardProgress: View
+    private lateinit var tvOverallLabel: TextView
+    private lateinit var tvOverallPercent: TextView
+    private lateinit var barOverall: ProgressBar
+    private lateinit var tvCurrentVideo: TextView
+    private lateinit var barCurrent: ProgressBar
+
+    // list + empty state
+    private lateinit var tvVideoSectionHeader: TextView
+    private lateinit var rvVideos: RecyclerView
+    private lateinit var emptyState: View
+    private val adapter = BatchVideoAdapter()
+
+    private var patientIdArg: Int = -1
+    private var patientHeight: Int = 0
+    private val rows: MutableList<BatchVideoRow> = mutableListOf()
+    private var isRunning = false
+    private var doneCount = 0
+    private var failedCount = 0
+    private var lastScore: Int? = null
+    // null = use per-video metadata dates; set = override all videos with this date
+    private var overrideDateMillis: Long? = null
+    private val dateFormat = SimpleDateFormat("MMM d, yyyy", Locale.getDefault())
+
+    private val pickVideos =
+        registerForActivityResult(ActivityResultContracts.PickMultipleVisualMedia(50)) { uris ->
+            if (uris.isEmpty()) return@registerForActivityResult
+            val existing = rows.map { it.uri }.toSet()
+            val newUris = uris.filter { it !in existing }
+            newUris.forEach { uri ->
+                rows.add(BatchVideoRow(uri = uri, displayName = lookupName(uri)))
+            }
+            refreshListUi()
+            // Extract metadata dates in background; switch back to Main to write rows
+            lifecycleScope.launch(Dispatchers.IO) {
+                newUris.forEach { uri ->
+                    val date = extractRecordingDate(this@BatchAnalysisActivity, uri)
+                    withContext(Dispatchers.Main) {
+                        val idx = rows.indexOfFirst { it.uri == uri }
+                        if (idx >= 0) {
+                            rows[idx] = rows[idx].copy(recordedDateMillis = date)
+                            adapter.submitList(rows.toList())
+                        }
+                    }
+                }
+            }
+        }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_batch_analysis)
+
+        patientIdArg = intent.getIntExtra(EXTRA_PATIENT_ID, -1)
+        if (patientIdArg <= 0) {
+            Toast.makeText(this, "Invalid patient", Toast.LENGTH_SHORT).show()
+            finish(); return
+        }
+
+        setupCommonHeader("Batch Analysis")
+        setCustomBackAction { confirmBackIfRunning() }
+
+        bindViews()
+        setupList()
+        loadPatient()
+    }
+
+    override fun onBackPressed() {
+        confirmBackIfRunning()
+    }
+
+    private fun bindViews() {
+        tvPatientName = findViewById(R.id.tvBatchPatientName)
+        tvPatientId = findViewById(R.id.tvBatchPatientId)
+        tvSelectedCount = findViewById(R.id.tvBatchSelectedCount)
+        tvDoneCount = findViewById(R.id.tvBatchDoneCount)
+        tvFailedCount = findViewById(R.id.tvBatchFailedCount)
+        tvLastScore = findViewById(R.id.tvBatchLastScore)
+
+        btnPick = findViewById(R.id.btnBatchPick)
+        btnStart = findViewById(R.id.btnBatchStart)
+        btnOverrideDate = findViewById(R.id.btnOverrideDate)
+        tvOverrideDateValue = findViewById(R.id.tvOverrideDateValue)
+
+        cardProgress = findViewById(R.id.cardBatchProgress)
+        tvOverallLabel = findViewById(R.id.tvBatchOverallLabel)
+        tvOverallPercent = findViewById(R.id.tvBatchOverallPercent)
+        barOverall = findViewById(R.id.barBatchOverall)
+        tvCurrentVideo = findViewById(R.id.tvBatchCurrentVideo)
+        barCurrent = findViewById(R.id.barBatchCurrent)
+
+        tvVideoSectionHeader = findViewById(R.id.tvVideoSectionHeader)
+        rvVideos = findViewById(R.id.rvBatchVideos)
+        emptyState = findViewById(R.id.batchEmptyState)
+
+        btnPick.setOnClickListener {
+            if (isRunning) return@setOnClickListener
+            pickVideos.launch(
+                PickVisualMediaRequest.Builder()
+                    .setMediaType(ActivityResultContracts.PickVisualMedia.VideoOnly)
+                    .build()
+            )
+        }
+        btnStart.setOnClickListener {
+            if (isRunning || rows.none { it.status == BatchVideoStatus.QUEUED }) return@setOnClickListener
+            startBatch()
+        }
+        btnOverrideDate.setOnClickListener {
+            if (isRunning) return@setOnClickListener
+            showOverrideDatePicker()
+        }
+    }
+
+    private fun showOverrideDatePicker() {
+        val cal = Calendar.getInstance().apply {
+            timeInMillis = overrideDateMillis ?: System.currentTimeMillis()
+        }
+        val dialog = DatePickerDialog(
+            this,
+            R.style.Theme_GaitVision_DatePicker,
+            { _, year, month, day ->
+                overrideDateMillis = Calendar.getInstance().apply {
+                    set(year, month, day, 0, 0, 0)
+                    set(Calendar.MILLISECOND, 0)
+                }.timeInMillis
+                updateOverrideDateDisplay()
+            },
+            cal.get(Calendar.YEAR), cal.get(Calendar.MONTH), cal.get(Calendar.DAY_OF_MONTH)
+        )
+        dialog.datePicker.maxDate = System.currentTimeMillis()
+        // "Clear" button resets the override back to metadata mode
+        dialog.setButton(DatePickerDialog.BUTTON_NEUTRAL, "Clear override") { _, _ ->
+            overrideDateMillis = null
+            updateOverrideDateDisplay()
+        }
+        dialog.show()
+        val white = ContextCompat.getColor(this, R.color.text_white)
+        dialog.getButton(DatePickerDialog.BUTTON_POSITIVE)?.setTextColor(white)
+        dialog.getButton(DatePickerDialog.BUTTON_NEGATIVE)?.setTextColor(white)
+        dialog.getButton(DatePickerDialog.BUTTON_NEUTRAL)?.setTextColor(white)
+    }
+
+    private fun updateOverrideDateDisplay() {
+        if (overrideDateMillis != null) {
+            tvOverrideDateValue.text = "Override: ${dateFormat.format(Date(overrideDateMillis!!))}"
+            tvOverrideDateValue.setTextColor(ContextCompat.getColor(this, R.color.icon_light_blue))
+        } else {
+            tvOverrideDateValue.text = "Use metadata dates"
+            tvOverrideDateValue.setTextColor(ContextCompat.getColor(this, R.color.chart_axis_text))
+        }
+    }
+
+    private fun setupList() {
+        rvVideos.layoutManager = LinearLayoutManager(this)
+        rvVideos.adapter = adapter
+        adapter.onDateEditClick = { uri, currentMillis ->
+            if (!isRunning) showPerVideoDatePicker(uri, currentMillis)
+        }
+    }
+
+    private fun showPerVideoDatePicker(uri: Uri, currentMillis: Long?) {
+        val cal = Calendar.getInstance().apply {
+            timeInMillis = currentMillis ?: System.currentTimeMillis()
+        }
+        val dialog = DatePickerDialog(
+            this,
+            R.style.Theme_GaitVision_DatePicker,
+            { _, year, month, day ->
+                val selected = Calendar.getInstance().apply {
+                    set(year, month, day, 0, 0, 0)
+                    set(Calendar.MILLISECOND, 0)
+                }.timeInMillis
+                val idx = rows.indexOfFirst { it.uri == uri }
+                if (idx >= 0) {
+                    rows[idx] = rows[idx].copy(recordedDateMillis = selected)
+                    adapter.submitList(rows.toList())
+                }
+            },
+            cal.get(Calendar.YEAR), cal.get(Calendar.MONTH), cal.get(Calendar.DAY_OF_MONTH)
+        )
+        dialog.datePicker.maxDate = System.currentTimeMillis()
+        dialog.show()
+        val white = ContextCompat.getColor(this, R.color.text_white)
+        dialog.getButton(DatePickerDialog.BUTTON_POSITIVE)?.setTextColor(white)
+        dialog.getButton(DatePickerDialog.BUTTON_NEGATIVE)?.setTextColor(white)
+        dialog.getButton(DatePickerDialog.BUTTON_NEUTRAL)?.setTextColor(white)
+    }
+
+    private fun loadPatient() {
+        lifecycleScope.launch {
+            val db = AppDatabase.getDatabase(this@BatchAnalysisActivity)
+            val patient = withContext(Dispatchers.IO) {
+                db.patientDao().getPatientById(patientIdArg)
+            }
+            if (patient == null) {
+                Toast.makeText(this@BatchAnalysisActivity, "Patient not found", Toast.LENGTH_SHORT).show()
+                finish(); return@launch
+            }
+            patientHeight = patient.height
+            tvPatientName.text = patient.fullName
+            tvPatientId.text = "ID ${patient.participantId ?: "—"}"
+        }
+    }
+
+    private fun refreshListUi() {
+        adapter.submitList(rows.toList())
+        tvSelectedCount.text = rows.size.toString()
+        val anyQueued = rows.any { it.status == BatchVideoStatus.QUEUED }
+        btnStart.alpha = if (anyQueued && !isRunning) 1f else 0.4f
+        emptyState.visibility = if (rows.isEmpty()) View.VISIBLE else View.GONE
+        if (rows.isEmpty()) {
+            tvVideoSectionHeader.visibility = View.GONE
+        } else {
+            tvVideoSectionHeader.visibility = View.VISIBLE
+            tvVideoSectionHeader.text = if (isRunning) {
+                val done = rows.count { it.status == BatchVideoStatus.DONE }
+                val failed = rows.count { it.status == BatchVideoStatus.FAILED }
+                val suffix = buildString {
+                    if (done > 0) append("$done done")
+                    if (done > 0 && failed > 0) append(", ")
+                    if (failed > 0) append("$failed failed")
+                }
+                if (suffix.isEmpty()) "Running…" else "Running — $suffix"
+            } else {
+                val n = rows.size
+                "$n video${if (n != 1) "s" else ""} selected"
+            }
+        }
+    }
+
+    private fun startBatch() {
+        isRunning = true
+        cardProgress.visibility = View.VISIBLE
+        btnPick.alpha = 0.4f
+        btnStart.alpha = 0.4f
+
+        lifecycleScope.launch {
+            try {
+            val db = AppDatabase.getDatabase(this@BatchAnalysisActivity)
+            // make sure patient row exists, mirrors AnalysisActivity
+            val patient = withContext(Dispatchers.IO) {
+                PatientRepository(db.patientDao())
+                    .findOrCreatePatientByParticipantId(patientIdArg, patientHeight)
+            }
+            val resolvedPatientId = patient.participantId ?: patientIdArg
+
+            val total = rows.size
+            for (i in rows.indices) {
+                val row = rows[i]
+                if (row.status != BatchVideoStatus.QUEUED) continue
+
+                updateRow(i, row.copy(status = BatchVideoStatus.RUNNING))
+                tvOverallLabel.text = "Video ${i + 1} of $total"
+                val overallPct = (i * 100 / total)
+                barOverall.progress = overallPct
+                tvOverallPercent.text = "$overallPct%"
+                tvCurrentVideo.text = "Processing ${row.displayName}"
+                barCurrent.progress = 0
+
+                try {
+                    runOneVideo(row, resolvedPatientId, db)
+                    val score = AnalysisSession.scoringResult?.getScoreForDatabase()?.toInt()
+                    lastScore = score
+                    doneCount++
+                    updateRow(i, row.copy(status = BatchVideoStatus.DONE, score = score))
+                } catch (e: Exception) {
+                    Log.e("BatchAnalysis", "video failed: ${row.displayName}", e)
+                    failedCount++
+                    updateRow(
+                        i,
+                        row.copy(
+                            status = BatchVideoStatus.FAILED,
+                            errorMessage = e.message?.take(60) ?: "Failed"
+                        )
+                    )
+                }
+
+                tvDoneCount.text = doneCount.toString()
+                tvFailedCount.text = failedCount.toString()
+                tvFailedCount.setTextColor(ContextCompat.getColor(
+                    this@BatchAnalysisActivity,
+                    if (failedCount > 0) R.color.score_poor else R.color.chart_axis_text
+                ))
+                tvLastScore.text = lastScore?.toString() ?: "—"
+                refreshListUi()  // keeps section header in sync ("Running — 2 done")
+            }
+
+            // batch finished
+            barOverall.progress = 100
+            tvOverallPercent.text = "100%"
+            tvOverallLabel.text = "Done — $doneCount ok, $failedCount failed"
+            tvCurrentVideo.text = ""
+            barCurrent.progress = 0
+            Toast.makeText(
+                this@BatchAnalysisActivity,
+                "Batch complete: $doneCount saved, $failedCount failed",
+                Toast.LENGTH_LONG
+            ).show()
+            } finally {
+                // always release the running lock, even if something unexpected throws
+                isRunning = false
+                btnPick.alpha = 1f
+                refreshListUi()
+            }
+        }
+    }
+
+    private suspend fun runOneVideo(row: BatchVideoRow, patientId: Int, db: AppDatabase) {
+        // reset first so stale results from the previous video can't leak into this one
+        AnalysisSession.reset()
+        AnalysisSession.galleryUri = row.uri
+        AnalysisSession.currentPatientId = patientId
+        AnalysisSession.participantId = patientId
+        AnalysisSession.participantHeight = patientHeight
+        // override wins over metadata; metadata wins over "right now"
+        AnalysisSession.recordingDate = overrideDateMillis
+            ?: row.recordedDateMillis
+            ?: System.currentTimeMillis()
+
+        val outPath = "${cacheDir.absolutePath}/batch_${System.currentTimeMillis()}.mp4"
+
+        AnalysisSession.editedUri = withContext(Dispatchers.IO) {
+            File(outPath).takeIf { it.exists() }?.delete()
+            ProcVidEmpty(this@BatchAnalysisActivity, outPath) { _, percent ->
+                runOnUiThread { barCurrent.progress = percent }
+            }
+        }
+
+        if (AnalysisSession.extractedFeatures != null) {
+            persistCurrentSession(
+                context = this@BatchAnalysisActivity,
+                db = db,
+                patientId = patientId,
+                videoFileName = row.displayName,
+            )
+        } else {
+            throw IllegalStateException("no gait features extracted")
+        }
+
+        // overlay file not needed in batch mode, clean up now
+        withContext(Dispatchers.IO) { File(outPath).takeIf { it.exists() }?.delete() }
+    }
+
+    private fun updateRow(index: Int, newRow: BatchVideoRow) {
+        rows[index] = newRow
+        adapter.submitList(rows.toList())
+    }
+
+    private fun lookupName(uri: Uri) =
+        lookupDisplayName(this, uri).ifBlank { uri.lastPathSegment ?: "video" }
+
+    private fun confirmBackIfRunning() {
+        if (!isRunning) { finish(); return }
+        AlertDialog.Builder(this)
+            .setTitle("Batch in progress")
+            .setMessage("A batch run is still going. Leaving will cancel the remaining videos. Already-saved analyses are kept.")
+            .setPositiveButton("Leave") { _, _ -> finish() }
+            .setNegativeButton("Stay", null)
+            .show()
+    }
+}

--- a/app/src/main/java/GaitVision/com/ui/PatientProfileActivity.kt
+++ b/app/src/main/java/GaitVision/com/ui/PatientProfileActivity.kt
@@ -101,6 +101,9 @@ class PatientProfileActivity : BaseActivity() {
         findViewById<LinearLayout>(R.id.btnNewAnalysis).setOnClickListener {
             startNewAnalysis()
         }
+        findViewById<LinearLayout>(R.id.btnBatchAnalysis).setOnClickListener {
+            startBatchAnalysis()
+        }
         findViewById<LinearLayout>(R.id.btnViewHistory).setOnClickListener {
             openAnalysisHistory()
         }
@@ -288,6 +291,13 @@ class PatientProfileActivity : BaseActivity() {
             intent.putExtra("fromPatientProfile", true)
             startActivity(intent)
         }
+    }
+
+    private fun startBatchAnalysis() {
+        val patient = currentPatient ?: return
+        val intent = Intent(this, BatchAnalysisActivity::class.java)
+        intent.putExtra(BatchAnalysisActivity.EXTRA_PATIENT_ID, patient.participantId ?: patientIdArg)
+        startActivity(intent)
     }
 
     private fun showDeleteConfirmation() {

--- a/app/src/main/java/GaitVision/com/ui/ProgressOverTimeActivity.kt
+++ b/app/src/main/java/GaitVision/com/ui/ProgressOverTimeActivity.kt
@@ -92,7 +92,8 @@ class ProgressOverTimeActivity : BaseActivity() {
 
         if (patientIdArg <= 0) { finish(); return }
 
-        setupCommonHeader("Progress — $patientName")
+        setupCommonHeader("Progress")
+        setHeaderSubtitle(patientName)
 
         analysisResultDao = AppDatabase.getDatabase(this).analysisResultDao()
         chartContainer    = findViewById(R.id.chartContainer)

--- a/app/src/main/java/GaitVision/com/ui/VideoPickeractivity.kt
+++ b/app/src/main/java/GaitVision/com/ui/VideoPickeractivity.kt
@@ -12,14 +12,19 @@ import android.widget.Toast
 import android.net.Uri
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.result.PickVisualMediaRequest
+import androidx.lifecycle.lifecycleScope
 import GaitVision.com.R
 import GaitVision.com.AnalysisSession
+import GaitVision.com.extractRecordingDate
 import android.widget.ImageButton
 import android.app.DatePickerDialog
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
 import java.util.Date
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class VideoPickerActivity : BaseActivity() {
 
@@ -79,6 +84,16 @@ class VideoPickerActivity : BaseActivity() {
                     videoView.setVideoURI(videoUri)
                     videoView.start()
 
+                    // Pre-fill the date picker from embedded metadata.
+                    // Clinician still has to confirm (or change) before hitting Continue.
+                    lifecycleScope.launch(Dispatchers.IO) {
+                        val meta = extractRecordingDate(this@VideoPickerActivity, videoUri)
+                        if (meta != null) withContext(Dispatchers.Main) {
+                            selectedDateMillis = meta
+                            updateDateDisplay()
+                        }
+                    }
+
                     Log.d("VideoPicker", "Video playback started")
                 } ?: run {
                     Log.e("VideoPicker", "URI is null - no video selected or permission denied")
@@ -135,10 +150,11 @@ class VideoPickerActivity : BaseActivity() {
 
         val datePickerDialog = DatePickerDialog(
             this,
+            R.style.Theme_GaitVision_DatePicker,
             { _, selectedYear, selectedMonth, selectedDay ->
                 val selectedCalendar = Calendar.getInstance().apply {
                     set(selectedYear, selectedMonth, selectedDay)
-                    // Normalize to start of day — time of day is not used by this app
+                    // normalize to start of day, app doesn't use time of day
                     set(Calendar.HOUR_OF_DAY, 0)
                     set(Calendar.MINUTE, 0)
                     set(Calendar.SECOND, 0)
@@ -154,6 +170,12 @@ class VideoPickerActivity : BaseActivity() {
         // Ensure user can't select future dates
         datePickerDialog.datePicker.maxDate = System.currentTimeMillis()
         datePickerDialog.show()
+        // Material's TextButton.Dialog uses a state-list selector for text
+        // color that ignores theme attrs, so just force white here.
+        val white = androidx.core.content.ContextCompat.getColor(this, R.color.text_white)
+        datePickerDialog.getButton(DatePickerDialog.BUTTON_POSITIVE)?.setTextColor(white)
+        datePickerDialog.getButton(DatePickerDialog.BUTTON_NEGATIVE)?.setTextColor(white)
+        datePickerDialog.getButton(DatePickerDialog.BUTTON_NEUTRAL)?.setTextColor(white)
     }
 
     private fun updateDateDisplay() {

--- a/app/src/main/java/GaitVision/com/ui/adapter/BatchVideoAdapter.kt
+++ b/app/src/main/java/GaitVision/com/ui/adapter/BatchVideoAdapter.kt
@@ -1,0 +1,106 @@
+package GaitVision.com.ui.adapter
+
+import android.net.Uri
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import GaitVision.com.R
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+// One row per video the user picked for the batch.
+data class BatchVideoRow(
+    val uri: Uri,
+    val displayName: String,
+    val status: BatchVideoStatus = BatchVideoStatus.QUEUED,
+    val score: Int? = null,
+    val errorMessage: String? = null,
+    // null = still extracting or not found; shown as "Date unknown" while queued
+    val recordedDateMillis: Long? = null,
+)
+
+enum class BatchVideoStatus { QUEUED, RUNNING, DONE, FAILED }
+
+class BatchVideoAdapter :
+    ListAdapter<BatchVideoRow, BatchVideoAdapter.ViewHolder>(DIFF) {
+
+    // Activity sets this to open a per-row date picker; null = rows not tappable
+    var onDateEditClick: ((uri: Uri, currentMillis: Long?) -> Unit)? = null
+
+    companion object {
+        private val DIFF = object : DiffUtil.ItemCallback<BatchVideoRow>() {
+            override fun areItemsTheSame(a: BatchVideoRow, b: BatchVideoRow) = a.uri == b.uri
+            override fun areContentsTheSame(a: BatchVideoRow, b: BatchVideoRow) = a == b
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.item_batch_video, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    inner class ViewHolder(item: View) : RecyclerView.ViewHolder(item) {
+        private val tvName: TextView = item.findViewById(R.id.tvVideoName)
+        private val tvStatus: TextView = item.findViewById(R.id.tvVideoStatus)
+        private val tvScore: TextView = item.findViewById(R.id.tvVideoScore)
+        private val dateFmt = SimpleDateFormat("MMM d, yyyy", Locale.getDefault())
+
+        fun bind(row: BatchVideoRow) {
+            val ctx = itemView.context
+            tvName.text = row.displayName
+
+            val isQueued = row.status == BatchVideoStatus.QUEUED
+
+            // While queued, show the extracted (or overridden) recording date.
+            // Append "· tap to edit" as a low-key affordance hint.
+            // Once the batch starts, status text takes over.
+            tvStatus.text = when (row.status) {
+                BatchVideoStatus.QUEUED -> {
+                    val dateStr = row.recordedDateMillis
+                        ?.let { dateFmt.format(Date(it)) }
+                        ?: "Date unknown"
+                    "$dateStr · tap to edit"
+                }
+                BatchVideoStatus.RUNNING -> "Running…"
+                BatchVideoStatus.DONE -> "Done"
+                BatchVideoStatus.FAILED -> row.errorMessage ?: "Failed"
+            }
+            tvStatus.setTextColor(ContextCompat.getColor(ctx, when (row.status) {
+                BatchVideoStatus.QUEUED -> if (row.recordedDateMillis != null)
+                    R.color.chart_axis_text else R.color.score_none
+                BatchVideoStatus.RUNNING -> R.color.icon_light_blue
+                BatchVideoStatus.DONE -> R.color.score_good
+                BatchVideoStatus.FAILED -> R.color.score_poor
+            }))
+
+            // Only QUEUED rows are editable
+            itemView.setOnClickListener {
+                if (isQueued) onDateEditClick?.invoke(row.uri, row.recordedDateMillis)
+            }
+
+            if (row.score != null) {
+                tvScore.text = row.score.toString()
+                val color = when {
+                    row.score >= 80 -> R.color.score_good
+                    row.score >= 60 -> R.color.score_warn
+                    else -> R.color.score_poor
+                }
+                tvScore.setTextColor(ContextCompat.getColor(ctx, color))
+            } else {
+                tvScore.text = "—"
+                tvScore.setTextColor(ContextCompat.getColor(ctx, R.color.score_none))
+            }
+        }
+    }
+}

--- a/app/src/main/res/drawable/ic_calendar_24.xml
+++ b/app/src/main/res/drawable/ic_calendar_24.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M20,3h-1V1h-2v2H7V1H5v2H4C2.9,3 2,3.9 2,5v16c0,1.1 0.9,2 2,2h16c1.1,0 2,-0.9 2,-2V5C22,3.9 21.1,3 20,3zM20,21H4V8h16V21zM9,10H7v2h2V10zM13,10h-2v2h2V10zM17,10h-2v2h2V10zM9,14H7v2h2V14zM13,14h-2v2h2V14zM17,14h-2v2h2V14z" />
+</vector>

--- a/app/src/main/res/layout/activity_batch_analysis.xml
+++ b/app/src/main/res/layout/activity_batch_analysis.xml
@@ -1,0 +1,458 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="#1A1A2E">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <include layout="@layout/layout_common_header" />
+
+        <!-- Patient identity card -->
+        <androidx.cardview.widget.CardView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="12dp"
+            app:cardCornerRadius="14dp"
+            app:cardBackgroundColor="@color/card_surface_dark"
+            app:cardElevation="3dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="18dp">
+
+                <TextView
+                    android:id="@+id/tvBatchPatientName"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    tools:text="John Doe"
+                    android:textColor="@color/text_white"
+                    android:textSize="20sp"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/tvBatchPatientId"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    tools:text="ID 0001"
+                    android:textColor="@color/table_header_text"
+                    android:textSize="12sp"
+                    android:textStyle="bold"
+                    android:layout_marginTop="2dp" />
+
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:background="#33FFFFFF"
+                    android:layout_marginTop="14dp"
+                    android:layout_marginBottom="12dp" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal">
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="SELECTED"
+                            android:textColor="@color/chart_axis_text"
+                            android:textSize="10sp"
+                            android:letterSpacing="0.1" />
+                        <TextView
+                            android:id="@+id/tvBatchSelectedCount"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="0"
+                            android:textColor="@color/text_white"
+                            android:textSize="18sp"
+                            android:textStyle="bold" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="DONE"
+                            android:textColor="@color/chart_axis_text"
+                            android:textSize="10sp"
+                            android:letterSpacing="0.1" />
+                        <TextView
+                            android:id="@+id/tvBatchDoneCount"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="0"
+                            android:textColor="@color/score_good"
+                            android:textSize="18sp"
+                            android:textStyle="bold" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="FAILED"
+                            android:textColor="@color/chart_axis_text"
+                            android:textSize="10sp"
+                            android:letterSpacing="0.1" />
+                        <TextView
+                            android:id="@+id/tvBatchFailedCount"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="0"
+                            android:textColor="@color/chart_axis_text"
+                            android:textSize="18sp"
+                            android:textStyle="bold" />
+                    </LinearLayout>
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="LAST SCORE"
+                            android:textColor="@color/chart_axis_text"
+                            android:textSize="10sp"
+                            android:letterSpacing="0.1" />
+                        <TextView
+                            android:id="@+id/tvBatchLastScore"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="—"
+                            android:textColor="@color/score_none"
+                            android:textSize="18sp"
+                            android:textStyle="bold" />
+                    </LinearLayout>
+                </LinearLayout>
+
+            </LinearLayout>
+        </androidx.cardview.widget.CardView>
+
+        <!-- Action card: pick / start -->
+        <androidx.cardview.widget.CardView
+            android:id="@+id/cardBatchActions"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="12dp"
+            app:cardCornerRadius="14dp"
+            app:cardBackgroundColor="@color/card_surface_dark"
+            app:cardElevation="3dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical">
+
+                <LinearLayout
+                    android:id="@+id/btnBatchPick"
+                    android:layout_width="match_parent"
+                    android:layout_height="56dp"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:paddingStart="20dp"
+                    android:paddingEnd="20dp"
+                    android:background="?attr/selectableItemBackground"
+                    android:focusable="true"
+                    android:clickable="true">
+
+                    <ImageView
+                        android:layout_width="22dp"
+                        android:layout_height="22dp"
+                        android:src="@drawable/ic_movie_24"
+                        app:tint="@color/icon_light_blue"
+                        android:layout_marginEnd="16dp" />
+
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Pick Videos"
+                        android:textColor="@color/text_white"
+                        android:textSize="14sp"
+                        android:textStyle="bold" />
+
+                    <ImageView
+                        android:layout_width="18dp"
+                        android:layout_height="18dp"
+                        android:src="@drawable/ic_chevron_right"
+                        app:tint="@color/icon_light_blue" />
+                </LinearLayout>
+
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:background="#22FFFFFF" />
+
+                <!-- Override date: shown always; tapping opens a date picker -->
+                <LinearLayout
+                    android:id="@+id/btnOverrideDate"
+                    android:layout_width="match_parent"
+                    android:layout_height="56dp"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:paddingStart="20dp"
+                    android:paddingEnd="20dp"
+                    android:background="?attr/selectableItemBackground"
+                    android:focusable="true"
+                    android:clickable="true">
+
+                    <ImageView
+                        android:layout_width="22dp"
+                        android:layout_height="22dp"
+                        android:src="@drawable/ic_calendar_24"
+                        app:tint="@color/table_header_text"
+                        android:layout_marginEnd="16dp" />
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="RECORDING DATE"
+                            android:textColor="@color/chart_axis_text"
+                            android:textSize="10sp"
+                            android:letterSpacing="0.1" />
+
+                        <TextView
+                            android:id="@+id/tvOverrideDateValue"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="Use metadata dates"
+                            android:textColor="@color/chart_axis_text"
+                            android:textSize="13sp" />
+                    </LinearLayout>
+
+                    <ImageView
+                        android:layout_width="18dp"
+                        android:layout_height="18dp"
+                        android:src="@drawable/ic_chevron_right"
+                        app:tint="@color/table_header_text" />
+                </LinearLayout>
+
+                <View
+                    android:layout_width="match_parent"
+                    android:layout_height="1dp"
+                    android:background="#22FFFFFF" />
+
+                <LinearLayout
+                    android:id="@+id/btnBatchStart"
+                    android:layout_width="match_parent"
+                    android:layout_height="56dp"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:paddingStart="20dp"
+                    android:paddingEnd="20dp"
+                    android:background="?attr/selectableItemBackground"
+                    android:focusable="true"
+                    android:clickable="true"
+                    android:alpha="0.4">
+
+                    <ImageView
+                        android:layout_width="22dp"
+                        android:layout_height="22dp"
+                        android:src="@drawable/ic_check_24"
+                        app:tint="@color/icon_green"
+                        android:layout_marginEnd="16dp" />
+
+                    <TextView
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="Start Batch"
+                        android:textColor="@color/text_white"
+                        android:textSize="14sp"
+                        android:textStyle="bold" />
+
+                    <ImageView
+                        android:layout_width="18dp"
+                        android:layout_height="18dp"
+                        android:src="@drawable/ic_chevron_right"
+                        app:tint="@color/icon_green" />
+                </LinearLayout>
+
+            </LinearLayout>
+        </androidx.cardview.widget.CardView>
+
+        <!-- Progress card: shown only while a batch is running -->
+        <androidx.cardview.widget.CardView
+            android:id="@+id/cardBatchProgress"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="12dp"
+            android:visibility="gone"
+            app:cardCornerRadius="12dp"
+            app:cardBackgroundColor="@color/card_surface_dark"
+            app:cardElevation="2dp">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:padding="16dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical">
+
+                    <TextView
+                        android:id="@+id/tvBatchOverallLabel"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        tools:text="Video 1 of 12"
+                        android:textColor="@color/text_white"
+                        android:textSize="14sp"
+                        android:textStyle="bold" />
+
+                    <TextView
+                        android:id="@+id/tvBatchOverallPercent"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        tools:text="8%"
+                        android:textColor="@color/chart_axis_text"
+                        android:textSize="13sp" />
+                </LinearLayout>
+
+                <ProgressBar
+                    android:id="@+id/barBatchOverall"
+                    style="@android:style/Widget.ProgressBar.Horizontal"
+                    android:layout_width="match_parent"
+                    android:layout_height="6dp"
+                    android:max="100"
+                    android:progressTint="@color/icon_green"
+                    android:progressBackgroundTint="#333333"
+                    android:layout_marginTop="6dp" />
+
+                <TextView
+                    android:id="@+id/tvBatchCurrentVideo"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    tools:text="Processing IMG_0182.mp4"
+                    android:textColor="@color/chart_axis_text"
+                    android:textSize="12sp"
+                    android:layout_marginTop="10dp"
+                    android:singleLine="true"
+                    android:ellipsize="middle" />
+
+                <ProgressBar
+                    android:id="@+id/barBatchCurrent"
+                    style="@android:style/Widget.ProgressBar.Horizontal"
+                    android:layout_width="match_parent"
+                    android:layout_height="4dp"
+                    android:max="100"
+                    android:progressTint="@color/icon_light_blue"
+                    android:progressBackgroundTint="#333333"
+                    android:layout_marginTop="4dp" />
+
+            </LinearLayout>
+        </androidx.cardview.widget.CardView>
+
+        <!-- Section header: "3 videos selected" / "Video 2 of 6 · 1 done" while running -->
+        <TextView
+            android:id="@+id/tvVideoSectionHeader"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingStart="20dp"
+            android:paddingEnd="20dp"
+            android:paddingTop="4dp"
+            android:paddingBottom="6dp"
+            android:textColor="@color/chart_axis_text"
+            android:textSize="11sp"
+            android:letterSpacing="0.08"
+            android:textAllCaps="true"
+            android:visibility="gone"
+            tools:text="6 VIDEOS SELECTED" />
+
+        <!-- FrameLayout so the empty state sits on top of the list area only,
+             not over the cards above -->
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/rvBatchVideos"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:paddingStart="12dp"
+                android:paddingEnd="12dp"
+                android:paddingBottom="16dp"
+                android:clipToPadding="false" />
+
+            <LinearLayout
+                android:id="@+id/batchEmptyState"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="vertical"
+                android:gravity="center"
+                android:padding="32dp">
+
+                <ImageView
+                    android:layout_width="56dp"
+                    android:layout_height="56dp"
+                    android:src="@drawable/ic_movie_24"
+                    android:alpha="0.35"
+                    app:tint="@color/chart_axis_text" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="No videos picked"
+                    android:textColor="#AAAAAA"
+                    android:textSize="15sp"
+                    android:textStyle="bold"
+                    android:layout_marginTop="12dp" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Tap Pick Videos above to get started"
+                    android:textColor="#555555"
+                    android:textSize="12sp"
+                    android:gravity="center"
+                    android:layout_marginTop="4dp" />
+
+            </LinearLayout>
+
+        </FrameLayout>
+
+    </LinearLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/activity_patient_profile.xml
+++ b/app/src/main/res/layout/activity_patient_profile.xml
@@ -338,6 +338,48 @@
                         android:layout_height="1dp"
                         android:background="#22FFFFFF" />
 
+                    <!-- ── 1b. Batch Analysis ──────────────────────── -->
+                    <LinearLayout
+                        android:id="@+id/btnBatchAnalysis"
+                        android:layout_width="match_parent"
+                        android:layout_height="56dp"
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical"
+                        android:paddingStart="20dp"
+                        android:paddingEnd="20dp"
+                        android:background="?attr/selectableItemBackground"
+                        android:focusable="true"
+                        android:clickable="true">
+
+                        <ImageView
+                            android:layout_width="22dp"
+                            android:layout_height="22dp"
+                            android:src="@drawable/ic_folder_24"
+                            app:tint="@color/icon_purple"
+                            android:layout_marginEnd="16dp" />
+
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="Batch Analysis"
+                            android:textColor="#FFFFFF"
+                            android:textSize="14sp"
+                            android:textStyle="bold" />
+
+                        <ImageView
+                            android:layout_width="18dp"
+                            android:layout_height="18dp"
+                            android:src="@drawable/ic_chevron_right"
+                            app:tint="@color/icon_purple" />
+                    </LinearLayout>
+
+                    <!-- Divider -->
+                    <View
+                        android:layout_width="match_parent"
+                        android:layout_height="1dp"
+                        android:background="#22FFFFFF" />
+
                     <!-- ── 2. Analysis History ──────────────────────── -->
                     <LinearLayout
                         android:id="@+id/btnViewHistory"

--- a/app/src/main/res/layout/item_batch_video.xml
+++ b/app/src/main/res/layout/item_batch_video.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="4dp"
+    android:layout_marginBottom="8dp"
+    android:clickable="true"
+    android:focusable="true"
+    android:foreground="?attr/selectableItemBackground"
+    app:cardCornerRadius="12dp"
+    app:cardElevation="2dp"
+    app:cardBackgroundColor="@color/card_surface_dark">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="14dp"
+        android:gravity="center_vertical">
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/tvVideoName"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                tools:text="IMG_0182.mp4"
+                android:textColor="@color/text_white"
+                android:textSize="14sp"
+                android:textStyle="bold"
+                android:singleLine="true"
+                android:ellipsize="middle" />
+
+            <TextView
+                android:id="@+id/tvVideoStatus"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                tools:text="Queued"
+                android:textColor="@color/chart_axis_text"
+                android:textSize="12sp"
+                android:layout_marginTop="2dp" />
+        </LinearLayout>
+
+        <TextView
+            android:id="@+id/tvVideoScore"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            tools:text="86"
+            android:textColor="@color/score_none"
+            android:textSize="18sp"
+            android:textStyle="bold"
+            android:minWidth="40dp"
+            android:gravity="end" />
+
+    </LinearLayout>
+
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/layout_common_header.xml
+++ b/app/src/main/res/layout/layout_common_header.xml
@@ -17,13 +17,38 @@
         android:contentDescription="Back"
         app:tint="@color/white" />
 
-    <TextView
-        android:id="@+id/tvTitle"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_centerInParent="true"
-        android:textColor="@color/white"
-        android:textSize="24sp"
-        android:textStyle="bold" />
+        android:layout_toEndOf="@id/btnBack"
+        android:layout_centerVertical="true"
+        android:orientation="vertical"
+        android:gravity="center"
+        android:paddingEnd="56dp">
+
+        <TextView
+            android:id="@+id/tvTitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:textColor="@color/white"
+            android:textSize="22sp"
+            android:textStyle="bold"
+            android:singleLine="true"
+            android:ellipsize="end" />
+
+        <TextView
+            android:id="@+id/tvSubtitle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:gravity="center"
+            android:textColor="@color/table_header_text"
+            android:textSize="18sp"
+            android:visibility="gone"
+            android:singleLine="true"
+            android:ellipsize="end" />
+
+    </LinearLayout>
 
 </RelativeLayout>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -26,6 +26,27 @@
         <item name="android:windowExitAnimation">@anim/slide_out</item>
     </style>
 
+    <!-- Date picker dialog: dark surface to match the app. Calendar digits
+         use white via colorOnSurface; selected-day chip uses the app's light
+         blue accent with a dark digit inside (colorOnPrimary).
+         OK/Cancel button text is forced white in code (see VideoPickerActivity)
+         because Material's TextButton.Dialog sets textColor via a selector
+         that ignores colorPrimary. -->
+    <style name="Theme.GaitVision.DatePicker" parent="Theme.MaterialComponents.Dialog">
+        <item name="colorPrimary">@color/icon_light_blue</item>
+        <item name="colorAccent">@color/icon_light_blue</item>
+        <item name="colorOnPrimary">@color/text_primary</item>
+        <item name="colorControlActivated">@color/icon_light_blue</item>
+        <item name="colorControlNormal">@color/text_white</item>
+        <item name="colorControlHighlight">#33FFFFFF</item>
+        <item name="colorOnSurface">@color/text_white</item>
+        <item name="android:textColorPrimary">@color/text_white</item>
+        <item name="android:textColorSecondary">#CCCCCC</item>
+        <item name="android:textColorPrimaryInverse">@color/text_primary</item>
+        <item name="android:windowBackground">@color/card_surface_dark</item>
+        <item name="android:colorBackground">@color/card_surface_dark</item>
+    </style>
+
     <!-- Common UI Styles -->
 
     <!-- Activity Container -->


### PR DESCRIPTION
- new BatchAnalysisActivity: multi-video picker, sequential processing loop, continue on failure, per-row progress, back-while-running confirm dialog
- new BatchVideoAdapter: ListAdapter + DiffUtil, per-row status/date/score
- new SessionPersistence.kt: extracted DB save logic out of AnalysisActivity, shared by both single and batch flows
- new VideoMetadataUtils.kt: extracts capture date from MediaStore/embedded metadata; shared lookupDisplayName util (removes duplicate)
- imageProcessing.kt: dropped AppCompatActivity param from ProcVidEmpty, replaced with ProgressReporter callback (-38 lines, no more UI coupling)
- AnalysisActivity: wired progress callback, replaced saveToDatabase body with persistCurrentSession call (-81 lines)
- VideoPickerActivity: pre-fills recording date from video metadata on pick
- batch screen layouts: activity_batch_analysis.xml, item_batch_video.xml
- per-video tap-to-edit date picker + bulk override date control
- PatientProfileActivity: added Batch Analysis entry point
- common header: subtitle line for patient name (fixes overlap on history screens)
- date picker dark mode fix (3 iterations, forced button text color in code)
- .gitignore: batch/ folder and *.pdf