### PR TITLE
simplify quick analysis ui flow

### DIFF
--- a/app/src/main/java/GaitVision/com/ui/QuickAnalysisActivity.kt
+++ b/app/src/main/java/GaitVision/com/ui/QuickAnalysisActivity.kt
@@ -36,21 +36,11 @@ class QuickAnalysisActivity : BaseActivity() {
     }
 
     private fun setupButtons() {
-        findViewById<LinearLayout>(R.id.btnRecord).setOnClickListener {
+        findViewById<LinearLayout>(R.id.btnContinue).setOnClickListener {
             if (validateAndSaveInputs()) {
-                val intent = Intent(this, VideoPickerActivity::class.java)
-                intent.putExtra("mode", "record")
-                intent.putExtra(AnalysisActivity.EXTRA_SHOULD_SAVE, false)
-                startActivity(intent)
-            }
-        }
-
-        findViewById<LinearLayout>(R.id.btnSelect).setOnClickListener {
-            if (validateAndSaveInputs()) {
-                val intent = Intent(this, VideoPickerActivity::class.java)
-                intent.putExtra("mode", "gallery")
-                intent.putExtra(AnalysisActivity.EXTRA_SHOULD_SAVE, false)
-                startActivity(intent)
+                startActivity(Intent(this, VideoPickerActivity::class.java).apply {
+                    putExtra(AnalysisActivity.EXTRA_SHOULD_SAVE, false)
+                })
             }
         }
 

--- a/app/src/main/java/GaitVision/com/ui/QuickAnalysisActivity.kt
+++ b/app/src/main/java/GaitVision/com/ui/QuickAnalysisActivity.kt
@@ -2,7 +2,7 @@ package GaitVision.com.ui
 
 import android.content.Intent
 import android.os.Bundle
-import android.widget.LinearLayout
+import android.view.View
 import android.widget.EditText
 import GaitVision.com.R
 import GaitVision.com.AnalysisSession
@@ -11,6 +11,8 @@ class QuickAnalysisActivity : BaseActivity() {
 
     private lateinit var etFeet: EditText
     private lateinit var etInches: EditText
+    private lateinit var btnContinue: View
+    private lateinit var btnViewResults: View
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -29,14 +31,15 @@ class QuickAnalysisActivity : BaseActivity() {
     private fun initializeViews() {
         etFeet = findViewById(R.id.etFeet)
         etInches = findViewById(R.id.etInches)
+        btnContinue = findViewById(R.id.btnContinue)
+        btnViewResults = findViewById(R.id.btnViewResults)
 
-        // Set default height values
         etFeet.setText("5")
         etInches.setText("9")
     }
 
     private fun setupButtons() {
-        findViewById<LinearLayout>(R.id.btnContinue).setOnClickListener {
+        btnContinue.setOnClickListener {
             if (validateAndSaveInputs()) {
                 startActivity(Intent(this, VideoPickerActivity::class.java).apply {
                     putExtra(AnalysisActivity.EXTRA_SHOULD_SAVE, false)
@@ -44,7 +47,7 @@ class QuickAnalysisActivity : BaseActivity() {
             }
         }
 
-        findViewById<LinearLayout>(R.id.btnViewResults).setOnClickListener {
+        btnViewResults.setOnClickListener {
             startActivity(Intent(this, ResultsActivity::class.java))
         }
     }

--- a/app/src/main/res/layout/activity_quick_analysis.xml
+++ b/app/src/main/res/layout/activity_quick_analysis.xml
@@ -72,7 +72,7 @@
                 android:textSize="16sp" />
         </LinearLayout>
 
-        <!-- Video Selection Buttons -->
+        <!-- Continue to video picker -->
         <androidx.cardview.widget.CardView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -82,70 +82,38 @@
             app:cardElevation="3dp">
 
             <LinearLayout
+                android:id="@+id/btnContinue"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
+                android:layout_height="56dp"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:paddingStart="20dp"
+                android:paddingEnd="20dp"
+                android:background="?attr/selectableItemBackground"
+                android:focusable="true"
+                android:clickable="true">
 
-                <LinearLayout
-                    android:id="@+id/btnSelect"
+                <ImageView
+                    android:layout_width="22dp"
+                    android:layout_height="22dp"
+                    android:src="@drawable/ic_movie_24"
+                    app:tint="@color/icon_green"
+                    android:layout_marginEnd="16dp" />
+
+                <TextView
                     android:layout_width="0dp"
-                    android:layout_height="56dp"
+                    android:layout_height="wrap_content"
                     android:layout_weight="1"
-                    android:orientation="horizontal"
-                    android:gravity="center"
-                    android:background="?attr/selectableItemBackground"
-                    android:focusable="true"
-                    android:clickable="true">
+                    android:text="Continue"
+                    android:textColor="#FFFFFF"
+                    android:textSize="14sp"
+                    android:textStyle="bold" />
 
-                    <ImageView
-                        android:layout_width="20dp"
-                        android:layout_height="20dp"
-                        android:src="@drawable/ic_folder_24"
-                        app:tint="@color/icon_light_blue"
-                        android:layout_marginEnd="10dp" />
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="Gallery"
-                        android:textColor="#FFFFFF"
-                        android:textSize="14sp"
-                        android:textStyle="bold" />
-
-                </LinearLayout>
-
-                <View
-                    android:layout_width="1dp"
-                    android:layout_height="match_parent"
-                    android:background="#22FFFFFF" />
-
-                <LinearLayout
-                    android:id="@+id/btnRecord"
-                    android:layout_width="0dp"
-                    android:layout_height="56dp"
-                    android:layout_weight="1"
-                    android:orientation="horizontal"
-                    android:gravity="center"
-                    android:background="?attr/selectableItemBackground"
-                    android:focusable="true"
-                    android:clickable="true">
-
-                    <ImageView
-                        android:layout_width="20dp"
-                        android:layout_height="20dp"
-                        android:src="@drawable/baseline_videocam_24"
-                        app:tint="@color/icon_green"
-                        android:layout_marginEnd="10dp" />
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="Record"
-                        android:textColor="#FFFFFF"
-                        android:textSize="14sp"
-                        android:textStyle="bold" />
-
-                </LinearLayout>
+                <ImageView
+                    android:layout_width="18dp"
+                    android:layout_height="18dp"
+                    android:src="@drawable/ic_chevron_right"
+                    app:tint="@color/icon_light_blue" />
 
             </LinearLayout>
         </androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/activity_quick_analysis.xml
+++ b/app/src/main/res/layout/activity_quick_analysis.xml
@@ -74,24 +74,24 @@
 
         <!-- Continue to video picker -->
         <androidx.cardview.widget.CardView
+            android:id="@+id/btnContinue"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="12dp"
+            android:foreground="?attr/selectableItemBackground"
+            android:focusable="true"
+            android:clickable="true"
             app:cardCornerRadius="16dp"
             app:cardBackgroundColor="@color/card_surface_dark"
             app:cardElevation="3dp">
 
             <LinearLayout
-                android:id="@+id/btnContinue"
                 android:layout_width="match_parent"
                 android:layout_height="56dp"
                 android:orientation="horizontal"
                 android:gravity="center_vertical"
                 android:paddingStart="20dp"
-                android:paddingEnd="20dp"
-                android:background="?attr/selectableItemBackground"
-                android:focusable="true"
-                android:clickable="true">
+                android:paddingEnd="20dp">
 
                 <ImageView
                     android:layout_width="22dp"


### PR DESCRIPTION
previously the quick analysis screen let you enter height then select either record video or select video from gallery. both buttons lead to the main pipeline video picker screen where user is again asked if they want to record or go to gallery, so the first choice is redundant. i replaced the choice with a continue button. they can still enter height, even though our current models dont actually take that as input for anything. they may in the future, so the screen is still needed