### PR TITLE
feat(compliance): require professional review before CSV export

### DIFF
--- a/app/src/main/java/GaitVision/com/ui/ResultsActivity.kt
+++ b/app/src/main/java/GaitVision/com/ui/ResultsActivity.kt
@@ -14,7 +14,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import GaitVision.com.R
-import GaitVision.com.data.AnalysisResult
 import GaitVision.com.data.AppDatabase
 import GaitVision.com.AnalysisSession
 import GaitVision.com.gait.*
@@ -33,15 +32,14 @@ class ResultsActivity : BaseActivity() {
 
     private var calculatedScore: Double = 0.0
     private var resultId: Long = -1L
+    private var isProfessionallyReviewed = false
 
-    // Local state to avoid race conditions with singleton AnalysisSession
     private var localFeatures: GaitFeatures? = null
     private var localDiagnostics: GaitDiagnostics? = null
     private var localScore: ScoringResult? = null
     private var localParticipantId: Int = 0
     private var localVideoUri: Uri? = null
 
-    /** SAF file picker for CSV export -- user chooses save location */
     private val csvExportLauncher = registerForActivityResult(
         ActivityResultContracts.CreateDocument("text/csv")
     ) { uri -> uri?.let { writeCsvToUri(it) } }
@@ -57,17 +55,14 @@ class ResultsActivity : BaseActivity() {
         resultId = intent.getLongExtra(EXTRA_RESULT_ID, -1L)
 
         if (resultId > 0) {
-            // Load from DB into local state
             loadFromDatabase(resultId)
         } else {
-            // Copy from global session to local state (Live analysis path)
-            // We copy immediately so if a new analysis starts in bg, we hold onto these results
             localFeatures = AnalysisSession.extractedFeatures
             localDiagnostics = AnalysisSession.extractionDiagnostics
             localScore = AnalysisSession.scoringResult
             localParticipantId = AnalysisSession.participantId
             localVideoUri = AnalysisSession.galleryUri
-            
+
             calculateGaitScore()
         }
     }
@@ -82,6 +77,11 @@ class ResultsActivity : BaseActivity() {
 
     private fun setupButtons() {
         findViewById<LinearLayout>(R.id.btnExportCsv).setOnClickListener {
+            if (!isProfessionallyReviewed) {
+                showReviewDialog()
+                return@setOnClickListener
+            }
+
             exportCsvFiles()
         }
 
@@ -96,10 +96,18 @@ class ResultsActivity : BaseActivity() {
         }
     }
 
-    /**
-     * Load an AnalysisResult from DB and populate local variables.
-     * Does NOT touch AnalysisSession globals, preventing race conditions.
-     */
+    private fun showReviewDialog() {
+        AlertDialog.Builder(this)
+            .setTitle("Professional Review Required")
+            .setMessage("These results are AI-assisted and should be reviewed by a qualified professional before export.")
+            .setPositiveButton("Confirm Review") { _, _ ->
+                isProfessionallyReviewed = true
+                exportCsvFiles()
+            }
+            .setNegativeButton("Cancel", null)
+            .show()
+    }
+
     private fun loadFromDatabase(id: Long) {
         lifecycleScope.launch {
             val result = withContext(Dispatchers.IO) {
@@ -112,7 +120,6 @@ class ResultsActivity : BaseActivity() {
                 return@launch
             }
 
-            // Populate local state
             localFeatures = GaitFeatures(
                 cadence_spm = result.cadenceSpm ?: Float.NaN,
                 stride_time_s = result.strideTimeS ?: Float.NaN,
@@ -151,12 +158,15 @@ class ResultsActivity : BaseActivity() {
                 estimatedCadenceSpm = result.cadenceSpm ?: 0f,
                 walkingDirection = result.walkingDirection ?: "unknown",
                 wasFlipped = result.wasFlipped,
-                qualityFlag = try { QualityFlag.valueOf(result.qualityFlag ?: "OK") } catch (_: Exception) { QualityFlag.OK }
+                qualityFlag = try {
+                    QualityFlag.valueOf(result.qualityFlag ?: "OK")
+                } catch (_: Exception) {
+                    QualityFlag.OK
+                }
             )
 
             localParticipantId = result.patientId
-            // We don't have the original URI for history items usually, checking if we can get it from videoFileName isn't reliable for URI
-            localVideoUri = null 
+            localVideoUri = null
 
             calculateGaitScore()
         }
@@ -170,7 +180,8 @@ class ResultsActivity : BaseActivity() {
         if (pcFeatures != null && pcScore != null && pcFeatures.valid_stride_count > 0) {
             calculatedScore = pcScore.getScoreForDatabase()
             tvGaitScore.text = calculatedScore.toLong().toString()
-            tvScoreLabel.text = "${getScoreLabel(calculatedScore)}\n(${pcFeatures.valid_stride_count} strides, ${String.format("%.1f", pcFeatures.cadence_spm)} spm)"
+            tvScoreLabel.text =
+                "${getScoreLabel(calculatedScore)}\n(${pcFeatures.valid_stride_count} strides, ${String.format("%.1f", pcFeatures.cadence_spm)} spm)"
 
             tvAeScore.text = if (!pcScore.aeScore.isNaN()) pcScore.aeScore.toLong().toString() else "--"
             tvRidgeScore.text = if (!pcScore.ridgeScore.isNaN()) pcScore.ridgeScore.toLong().toString() else "--"
@@ -200,6 +211,7 @@ class ResultsActivity : BaseActivity() {
                 pcScore == null -> "Scoring failed to initialize"
                 else -> "Unknown error"
             }
+
             tvScoreLabel.text = errorMsg
             tvGaitScore.setTextColor(android.graphics.Color.parseColor("#F44336"))
         }
@@ -264,7 +276,8 @@ class ResultsActivity : BaseActivity() {
         }
 
         val filePrefix = if (localParticipantId == 0) {
-            val timestamp = java.text.SimpleDateFormat("yyyy-MM-dd_HH-mm-ss", java.util.Locale.US).format(java.util.Date())
+            val timestamp = java.text.SimpleDateFormat("yyyy-MM-dd_HH-mm-ss", java.util.Locale.US)
+                .format(java.util.Date())
             "${timestamp}_0"
         } else {
             localParticipantId.toString()
@@ -280,6 +293,7 @@ class ResultsActivity : BaseActivity() {
             val videoName = localVideoUri?.lastPathSegment
                 ?: diagnostics.videoId.takeIf { it.isNotBlank() }
                 ?: "unknown"
+
             val filePrefix = if (localParticipantId == 0) "0" else localParticipantId.toString()
 
             contentResolver.openOutputStream(uri)?.use { stream ->
@@ -291,6 +305,7 @@ class ResultsActivity : BaseActivity() {
                     participantId = filePrefix,
                     videoName = videoName
                 )
+
                 if (success) {
                     Toast.makeText(this, "CSV exported successfully", Toast.LENGTH_SHORT).show()
                 } else {

--- a/app/src/main/java/GaitVision/com/ui/ResultsActivity.kt
+++ b/app/src/main/java/GaitVision/com/ui/ResultsActivity.kt
@@ -21,6 +21,7 @@ import GaitVision.com.gait.*
 class ResultsActivity : BaseActivity() {
 
     companion object {
+        private const val KEY_PROFESSIONALLY_REVIEWED = "professionally_reviewed"
         const val EXTRA_RESULT_ID = "result_id"
     }
 
@@ -33,13 +34,15 @@ class ResultsActivity : BaseActivity() {
     private var calculatedScore: Double = 0.0
     private var resultId: Long = -1L
     private var isProfessionallyReviewed = false
-
+    
+    // Local state to avoid race conditions with singleton AnalysisSession
     private var localFeatures: GaitFeatures? = null
     private var localDiagnostics: GaitDiagnostics? = null
     private var localScore: ScoringResult? = null
     private var localParticipantId: Int = 0
     private var localVideoUri: Uri? = null
-
+    
+    /** SAF file picker for CSV export -- user chooses save location */
     private val csvExportLauncher = registerForActivityResult(
         ActivityResultContracts.CreateDocument("text/csv")
     ) { uri -> uri?.let { writeCsvToUri(it) } }
@@ -47,6 +50,8 @@ class ResultsActivity : BaseActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_results)
+
+        isProfessionallyReviewed = savedInstanceState?.getBoolean(KEY_PROFESSIONALLY_REVIEWED) ?: false
 
         setupCommonHeader("Analysis Results")
         initializeViews()
@@ -57,6 +62,8 @@ class ResultsActivity : BaseActivity() {
         if (resultId > 0) {
             loadFromDatabase(resultId)
         } else {
+            // Copy from global session to local state (Live analysis path)
+            // We copy immediately so if a new analysis starts in bg, we hold onto these results
             localFeatures = AnalysisSession.extractedFeatures
             localDiagnostics = AnalysisSession.extractionDiagnostics
             localScore = AnalysisSession.scoringResult
@@ -316,5 +323,10 @@ class ResultsActivity : BaseActivity() {
             Log.e("ResultsActivity", "Error exporting: ${e.message}", e)
             Toast.makeText(this, "Error exporting: ${e.message}", Toast.LENGTH_LONG).show()
         }
+         
     }
+override fun onSaveInstanceState(outState: Bundle) {
+    super.onSaveInstanceState(outState)
+    outState.putBoolean(KEY_PROFESSIONALLY_REVIEWED, isProfessionallyReviewed)
 }
+} 


### PR DESCRIPTION
Adds a confirmation step before exporting gait analysis results.

Changes:
- Added a confirmation dialog in ResultsActivity before CSV export
- Blocks export until the user confirms the results have been reviewed
- Kept changes limited to the results/export screen

Why:
Gait results are AI-assisted, so they should be reviewed by a professional before being exported or used.

Testing:
- Verified build works with ./gradlew.bat assembleDebug
- Confirmed export is blocked until confirmation